### PR TITLE
bump to ubuntu-24.04

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Garret Sidzaka"
 
@@ -22,10 +22,9 @@ RUN apt-get update \
 RUN dpkg --add-architecture i386 \
     && curl https://dl.winehq.org/wine-builds/winehq.key | apt-key add - \
     && apt-add-repository 'https://dl.winehq.org/wine-builds/ubuntu/' \
-    && apt-add-repository ppa:cybermax-dexter/sdl2-backport \
     && apt-get update \
     && apt-get install --install-recommends --assume-yes winehq-devel \
-    && pip3 install python-valve \
+    && pip3 install python-valve --break-system-packages \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
# Changes
Image: Bumped to 24.04
Repo: removed ppa since newer packages are in 24.04
pip3 install: added "--break-system-packages"

I build the image and pushed it here for testing: https://hub.docker.com/r/ejdesgaard/container-conanexiles/tags

#Build
Using podman-5.1.1
`~/.../container-conanexiles/src$ podman build -t dedicated-conan:1-2404-1 .`

# Test-run
`podman run -d -p 7777-7778:7777-7778/udp -p 7777:7777/tcp localhost/dedicated-conan:1-2404-1`

After a minute or so, it's possible to login to the server.