### PR TITLE
Add README memory crash/limit docs and a fix for get_available_build not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ If there is a folder with configurations found at `/tmp/docker-conanexiles` this
 
 Use the environment variable `CONANEXILES_SERVER_TYPE=pve` to use the pve template; otherwise the pvp template will be used if no configuration has been provided.
 
+### Host Tweaks
+
+Based on this [reddit thread discussing dedicated server on Linux hangs and players disconnect](https://www.reddit.com/r/ConanExiles/comments/1dbuiqd/dedicated_server_on_linux_hangs_and_players/) that user
+[whereismycow42](https://reddit.com/user/whereismycow42) posted with a solution, it's recommended to update `vm.max_map_count` to greater than the default value of `65536`. We tried to integrate this solution in the startup script to set the value in the docker container, but found that you need to set this at the host level as root. Please review the thread post and apply the appropriate fix so you can include as many mods as you want.
+
 ---
 
 ## Multi Instance Setup

--- a/src/usr/bin/conanexiles_controller
+++ b/src/usr/bin/conanexiles_controller
@@ -20,7 +20,7 @@ function get_available_build() {
     rm -rf /root/Steam/appcache
 
     # get available build id and return it
-    local _build_id=$(/steamcmd/steamcmd.sh +login anonymous +app_info_update 1 +app_info_print $APPID +quit | \
+    local _build_id=$(/steamcmd/steamcmd.sh +login anonymous +app_info_request $APPID +login anonymous +app_info_update 1 +login anonymous +app_info_print $APPID +logoff +quit | \
                     grep -EA 1000 "^\s+\"branches\"$" | grep -EA 5 "^\s+\"public\"$" | \
                     grep -m 1 -EB 10 "^\s+}" | grep -E "^\s+\"buildid\"\s+" | \
                     tr '[:blank:]"' ' ' | awk '{print $2}')


### PR DESCRIPTION
I've been trying for ever to figure out how to run this linux container that doesn't crash while running out of memory, so I don't have to startup a Windows VM to host conan exiles. I finally stumbled upon a solution the other day, per my update to the README.  This solution is in relation to the[ bug reported in the original repo ](https://github.com/alinmear/docker-conanexiles/issues/55) (which I really really want to be able to post the solution, but the repo is readonly!).

I stumbled on the solution [here](https://www.reddit.com/r/ConanExiles/comments/1dbuiqd/dedicated_server_on_linux_hangs_and_players/), and discovered that you need to update the host settings `sysctl  vm.max_map_count` to something more than the default. [Here's a little chart to show values equivalent to memory size](https://memgraph.com/docs/database-management/system-configuration#increasing-memory-map-areas).

I set mine to 1048576 and I've been running the container with a bunch of mods (including AoC) for a couple days now and it has not crashed! If I was lucky before this fix, it would run for a 2 - 3 hours then crash.

I also added a little fix to the `get_available_build` method because they just updated steamcmd recently and caused a little bug that[ is discussed here](https://github.com/ValveSoftware/steam-for-linux/issues/9683), and I applied one of the fixes suggested in the thread which I've only seen one failure on my instance since applying the fix.
